### PR TITLE
Typo correction. Changed reCAPTACHA to reCAPTCHA.

### DIFF
--- a/views/admin.php
+++ b/views/admin.php
@@ -12,7 +12,7 @@ use MW_WP_Form_reCAPTCHA\Classes\Functions;
     }
     ?>
 
-    <h1><?php _e('reCAPTACHA v3 Setting', Config::TEXTDOMAIN) ?></h1>
+    <h1><?php _e('reCAPTCHA v3 Setting', Config::TEXTDOMAIN) ?></h1>
 
     <p>
         <?php _e('Get Keys from <a href="https://www.google.com/recaptcha/admin/create" target="_blank">here</a>.', Config::TEXTDOMAIN) ?>


### PR DESCRIPTION
I have made a small correction to the code where there was a typo. 
- The word "reCAPTACHA" was misspelt, and I have corrected it to "reCAPTCHA". 
