### PR TITLE
submitとsubmitBackがあった場合に戻るになってしまうので押されたボタンを区別する

### DIFF
--- a/controllers/EnqueueController.php
+++ b/controllers/EnqueueController.php
@@ -23,7 +23,7 @@ class EnqueueController
 
             $data = <<< EOL
 grecaptcha.ready(function() {
-    jQuery('form').on('submit', function(e) {
+    document.querySelector('form').addEventListener('submit', function(e) {
         e.preventDefault();
         grecaptcha.execute('$site_key', {
             action: 'homepage'
@@ -38,7 +38,7 @@ grecaptcha.ready(function() {
                 confirmButton.value = confirmButtonValue;
                 confirmButton.name = "submitConfirm";
                 form.appendChild(confirmButton);
-            } else if (form.querySelector("[name=submitBack]")) {
+            } else if (e.submitter.name == 'submitBack' && form.querySelector("[name=submitBack]")) {
                 const backButtonValue = form.querySelector("[name=submitBack]").value;
                 const backButton = document.createElement("input");
                 backButton.type = "hidden";


### PR DESCRIPTION
お手数をおかけして申し訳ありません。

先日のPRでバグがあったためその修正です。
submitterを取得するため、jQueryのonからaddEventListnerに変えています。

https://wordpress.org/support/topic/%e3%83%95%e3%82%a9%e3%83%bc%e3%83%a0%e3%82%92%e9%80%81%e4%bf%a1%e3%83%9c%e3%82%bf%e3%83%b3%e3%81%8c%e6%8a%bc%e3%81%9b%e3%81%aa%e3%81%84/

※こちらの報告では1.1.3でも発生となっているので別の事象の可能性もありますが