### PR TITLE
サイトキーの検証とスクリプトキュー処理を改善

### DIFF
--- a/controllers/EnqueueController.php
+++ b/controllers/EnqueueController.php
@@ -16,10 +16,13 @@ class EnqueueController
     {
         global $post;
         $option = get_option(Config::OPTION);
-        $site_key = esc_html($option['site_key']);
+        $site_key = '';
+		if (is_array($option) && isset($option['site_key'])) {
+			$site_key = esc_html($option['site_key']);
+		}
         if (!empty($post) && has_shortcode($post->post_content, 'mwform_formkey') && !empty($site_key)) {
             wp_enqueue_script('jquery');
-            wp_enqueue_script("recaptcha-script", 'https://www.google.com/recaptcha/api.js?render=' . $site_key, array('jquery'), array(), true);
+            wp_enqueue_script("recaptcha-script", 'https://www.google.com/recaptcha/api.js?render=' . $site_key, array('jquery'), false, true);
 
             $data = <<< EOL
 grecaptcha.ready(function() {


### PR DESCRIPTION
### 変更内容
このプルリクエストでは、以下の二つの改修を行いました：
1. `$site_key`が適切に設定されているかのチェックを強化しました。これにより、`$option`が予期せぬ型（`bool`など）の場合に発生する警告を防ぎます。
2. スクリプトのエンキュー処理を改善し、バージョン指定のエラーを修正しました。`wp_enqueue_script` のバージョンパラメータが誤って配列で指定されていたため、これをデフォルト値（ `false` ）に変更しています。

### 背景
PHP 8.x環境下でのテスト中に、`$site_key`にアクセスする際に型の不一致による警告が発生していたため、これを解消する必要がありました。また、スクリプトのキュー処理での小さなバグも同時に修正しました。